### PR TITLE
support for ggplot2 versions < 3.0.0 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@ inst/doc
 package_dev.R
 .Rhistory
 .RData
+ALL.png
+Cumulative lift.png
+comparing_datasets_all_plots.png
+mnl.RDS
+v2.png
+xgb.RDS
+xgb3.RDS

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: modelplotr
 Type: Package
 Title: Plots to Evaluate the Business Performance of Predictive Models
-Version: 0.1
+Version: 0.2
 Authors@R: as.person(c(
     "Jurriaan Nagelkerke <jurriaan.nagelkerke@gmail.com> [aut, cre]", 
     "Pieter Marcus <pieter.marcus@persgroep.net> [aut]"))

--- a/R/plottingmodelplots.R
+++ b/R/plottingmodelplots.R
@@ -152,8 +152,8 @@ annotate_plot <- function(plot=plot,plot_input=plot_input_prepared,
       ggplot2::theme(
         axis.line = ggplot2::element_line(color="black"),
         axis.text.x = ggplot2::element_text(
-          face=c(rep("plain",pp$decile0+highlight_decile-1),"bold",rep("plain",10+pp$decile0-highlight_decile-1)),
-          size=c(rep(10,pp$decile0+highlight_decile-1),12,rep(10,10+pp$decile0-highlight_decile-1))))
+          face=c(rep("plain",pp$decile0+highlight_decile-1),"bold",rep("plain",10+pp$decile0-highlight_decile)),
+          size=c(rep(10,pp$decile0+highlight_decile-1),12,rep(10,10+pp$decile0-highlight_decile))))
     # make sure value labels for annotated points to X axis aren't clipped
     if(packageVersion("ggplot2") >= 3.0) plot <- plot + ggplot2::coord_cartesian(clip = 'off' )
     }


### PR DESCRIPTION
modelplotr now supports ggplot2 < 3.0.0 also for annotated plots (clip parameter is not available in ggplot2 < 3.0.0) and only gives a warning when ggplot < 3.0.0 is used. 

also a bug fix for annotating decile 10 for cumlift, response and cumresponse plots.