### PR TITLE
Added `h2o` support

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,3 @@
+^README\.Rmd$
 ^.*\.Rproj$
 ^\.Rproj\.user$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,8 @@ RoxygenNote: 6.0.1
 Suggests: 
     mlr (>= 2.12.1),
     caret (>= 6.0),
+    e1071,
+    h2o,
     knitr,
     rmarkdown,
     testthat,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     randomForest (>= 4.6.14),
     nnet(>= 7.3-12),
     ggfittext (>= 0.6.0)
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.1
 Suggests: 
     mlr (>= 2.12.1),
     caret (>= 6.0),

--- a/R/dataprepmodelplots.R
+++ b/R/dataprepmodelplots.R
@@ -111,7 +111,7 @@ prepare_scores_and_deciles <- function(datasets,
       # 1.2. get probabilities per target class from model and prepare
 
       # 1.2.1. mlr models
-      if(ifelse(is.null(attr(class(get(mdl)), "class")), "", attr(class(get(mdl)), "class")) == "WrappedModel") {
+      if(ifelse(is.null(class(get(mdl))), "", class(get(mdl))) == "WrappedModel") {
         cat(paste0('... scoring mlr model "',mdl,'" on dataset "',dataset,'".\n'))
         if (!requireNamespace("mlr", quietly = TRUE)) {
           stop("Package \"mlr\" needed for this function to work, but it's not installed. Please install it.",

--- a/R/dataprepmodelplots.R
+++ b/R/dataprepmodelplots.R
@@ -111,7 +111,7 @@ prepare_scores_and_deciles <- function(datasets,
       # 1.2. get probabilities per target class from model and prepare
 
       # 1.2.1. mlr models
-      if(ifelse(is.null(attr(class(get(mdl)), "class")), "", .) == "WrappedModel") {
+      if(ifelse(is.null(attr(class(get(mdl)), "class")), "", attr(class(get(mdl)), "class")) == "WrappedModel") {
         cat(paste0('... scoring mlr model "',mdl,'" on dataset "',dataset,'".\n'))
         if (!requireNamespace("mlr", quietly = TRUE)) {
           stop("Package \"mlr\" needed for this function to work, but it's not installed. Please install it.",
@@ -130,7 +130,7 @@ prepare_scores_and_deciles <- function(datasets,
           y_values <- colnames(probabilities)
         }
       # 1.2.3. h2o models
-      } else if (attr(class(get(mdl)), "package") == "h2o") {
+      } else if (ifelse(is.null(attr(class(get(mdl)), "package")), "", attr(class(get(mdl)), "package")) == "h2o") {
         cat(paste0('... scoring h2o model "',mdl,'" on dataset "',dataset,'".\n'))
         if (!requireNamespace("h2o", quietly = TRUE)) {
           stop("Package \"h2o\" needed for this function to work, but it's not installed. Please install it.",

--- a/R/modelplotr.R
+++ b/R/modelplotr.R
@@ -65,11 +65,20 @@
 #' #... or train models using caret
 #' rf = caret::train(Species ~.,data = train, method = "rf")
 #' mnl = caret::train(Species ~.,data = train, method = "multinom",trace = FALSE)
+#' #.. or train models using h2o
+#' h2o::h2o.init()
+#' h2o::h2o.no_progress()
+#' h2o_train = h2o::as.h2o(train)
+#' h2o_test = h2o::as.h2o(test)
+#' h2o_model <- h2o::h2o.gbm(y = "Species",
+#'                           x = setdiff(colnames(train), "Species"),
+#'                           training_frame = h2o_train,
+#'                           nfolds = 5)
 #' # preparation steps
 #' prepare_scores_and_deciles(datasets=list("train","test"),
 #'                       dataset_labels = list("train data","test data"),
-#'                       models = list("rf","mnl"),
-#'                       model_labels = list("random forest","multinomial logit"),
+#'                       models = list("rf","mnl", "h2o_model"),
+#'                       model_labels = list("random forest","multinomial logit", "H2O GBM"),
 #'                       target_column="Species")
 #' head(scores_and_deciles)
 #' aggregate_over_deciles()

--- a/README.Rmd
+++ b/README.Rmd
@@ -1,0 +1,26 @@
+---
+output: github_document
+---
+
+```{r setup, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>",
+  fig.path = "man/figures/README-",
+  out.width = "100%"
+)
+```
+
+# modelplotr
+
+Plots to evaluate the business performance of predictive models in R. A number of widely used plots to assess the quality of a predictive model from a business perspective can easily be created.Using these plots, it can be shown  how implementation of the model will impact business targets like response on a campaign. Also, the under/overperformance of a model on the train data compared to other datasets (test data, external validation data,...) can be visualized with a number of functions. See [this blog post](https://modelplot.github.io/intro_modelplotr.html) for further details and examples of using the package
+
+## Installation
+
+You can install the unreleased version of `modelplotr` from [GitHub]() with:
+
+```{r, eval = FALSE}
+install.packages("devtools")
+devtools::install_github("modelplot/modelplotr")
+```
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+
+modelplotr
+==========
+
+Plots to evaluate the business performance of predictive models in R. A number of widely used plots to assess the quality of a predictive model from a business perspective can easily be created.Using these plots, it can be shown how implementation of the model will impact business targets like response on a campaign. Also, the under/overperformance of a model on the train data compared to other datasets (test data, external validation data,...) can be visualized with a number of functions. See [this blog post](https://modelplot.github.io/intro_modelplotr.html) for further details and examples of using the package
+
+Installation
+------------
+
+You can install the unreleased version of `modelplotr` from [GitHub]() with:
+
+``` r
+install.packages("devtools")
+devtools::install_github("modelplot/modelplotr")
+```

--- a/man/modelplotr.Rd
+++ b/man/modelplotr.Rd
@@ -66,11 +66,20 @@ mnl = mlr::train(lrn, task)
 #... or train models using caret
 rf = caret::train(Species ~.,data = train, method = "rf")
 mnl = caret::train(Species ~.,data = train, method = "multinom",trace = FALSE)
+#.. or train models using h2o
+h2o::h2o.init()
+h2o::h2o.no_progress()
+h2o_train = h2o::as.h2o(train)
+h2o_test = h2o::as.h2o(test)
+h2o_model <- h2o::h2o.gbm(y = "Species",
+                          x = setdiff(colnames(train), "Species"),
+                          training_frame = h2o_train,
+                          nfolds = 5)
 # preparation steps
 prepare_scores_and_deciles(datasets=list("train","test"),
                       dataset_labels = list("train data","test data"),
-                      models = list("rf","mnl"),
-                      model_labels = list("random forest","multinomial logit"),
+                      models = list("rf","mnl", "h2o_model"),
+                      model_labels = list("random forest","multinomial logit", "H2O GBM"),
                       target_column="Species")
 head(scores_and_deciles)
 aggregate_over_deciles()

--- a/man/plot_all.Rd
+++ b/man/plot_all.Rd
@@ -4,8 +4,8 @@
 \alias{plot_all}
 \title{Create plot with all four evaluation plots}
 \usage{
-plot_all(data = plot_input, custom_line_colors = NA, save_fig = FALSE,
-  save_fig_filename = NA)
+plot_all(data = plot_input, custom_line_colors = NA,
+  save_fig = FALSE, save_fig_filename = NA)
 }
 \arguments{
 \item{data}{Dataframe. Dataframe needs to be created with \code{\link{plotting_scope}}

--- a/man/plot_cumgains.Rd
+++ b/man/plot_cumgains.Rd
@@ -5,8 +5,8 @@
 \title{Cumulative gains plot}
 \usage{
 plot_cumgains(data = plot_input, custom_line_colors = NA,
-  highlight_decile = NA, highlight_how = "plot_text", save_fig = FALSE,
-  save_fig_filename = NA)
+  highlight_decile = NA, highlight_how = "plot_text",
+  save_fig = FALSE, save_fig_filename = NA)
 }
 \arguments{
 \item{data}{Dataframe. Dataframe needs to be created with \code{\link{plotting_scope}}

--- a/man/plot_cumlift.Rd
+++ b/man/plot_cumlift.Rd
@@ -5,8 +5,8 @@
 \title{Cumulative Lift plot}
 \usage{
 plot_cumlift(data = plot_input, custom_line_colors = NA,
-  highlight_decile = NA, highlight_how = "plot_text", save_fig = FALSE,
-  save_fig_filename = NA)
+  highlight_decile = NA, highlight_how = "plot_text",
+  save_fig = FALSE, save_fig_filename = NA)
 }
 \arguments{
 \item{data}{Dataframe. Dataframe needs to be created with \code{\link{plotting_scope}}

--- a/man/plot_cumresponse.Rd
+++ b/man/plot_cumresponse.Rd
@@ -5,8 +5,8 @@
 \title{Cumulative Respose plot}
 \usage{
 plot_cumresponse(data = plot_input, custom_line_colors = NA,
-  highlight_decile = NA, highlight_how = "plot_text", save_fig = FALSE,
-  save_fig_filename = NA)
+  highlight_decile = NA, highlight_how = "plot_text",
+  save_fig = FALSE, save_fig_filename = NA)
 }
 \arguments{
 \item{data}{Dataframe. Dataframe needs to be created with \code{\link{plotting_scope}}

--- a/man/plot_response.Rd
+++ b/man/plot_response.Rd
@@ -5,8 +5,8 @@
 \title{Response plot}
 \usage{
 plot_response(data = plot_input, custom_line_colors = NA,
-  highlight_decile = NA, highlight_how = "plot_text", save_fig = FALSE,
-  save_fig_filename = NA)
+  highlight_decile = NA, highlight_how = "plot_text",
+  save_fig = FALSE, save_fig_filename = NA)
 }
 \arguments{
 \item{data}{Dataframe. Dataframe needs to be created with \code{\link{plotting_scope}}

--- a/man/plotting_scope.Rd
+++ b/man/plotting_scope.Rd
@@ -4,9 +4,10 @@
 \alias{plotting_scope}
 \title{Build 'plot_input' with subset for selected evaluation type.}
 \usage{
-plotting_scope(prepared_input = deciles_aggregate, scope = "no_comparison",
-  select_model_label = NA, select_dataset_label = NA,
-  select_targetclass = NA, select_smallest_targetclass = TRUE)
+plotting_scope(prepared_input = deciles_aggregate,
+  scope = "no_comparison", select_model_label = NA,
+  select_dataset_label = NA, select_targetclass = NA,
+  select_smallest_targetclass = TRUE)
 }
 \arguments{
 \item{prepared_input}{Dataframe. Dataframe resulting from function \code{\link{aggregate_over_deciles}()} or with similar

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -2,6 +2,3 @@ library(testthat)
 library(modelplotr)
 
 test_check("modelplotr")
-
-expect_equal(10, 10 + 1e-7)
-expect_identical(10, 10 + 1e-7)

--- a/tests/testthat/test-prepare_scores_and_deciles.R
+++ b/tests/testthat/test-prepare_scores_and_deciles.R
@@ -1,0 +1,122 @@
+context("prepare_scores_and_deciles")
+
+library(magrittr)
+library(testthat)
+# Generate some sample data -----------------------------------------------
+
+data(iris)
+
+# add some noise to iris to prevent perfect models
+addNoise <- function(x) round(rnorm(n=100,mean=mean(x),sd=sd(x)),1)
+
+iris_addnoise <- as.data.frame(lapply(iris[1:4], addNoise))
+
+iris_addnoise$Species <- sample(unique(iris$Species),100,replace=TRUE)
+
+iris <- rbind(iris,iris_addnoise)
+
+train_index =  sample(seq(1, nrow(iris)),size = 0.7*nrow(iris), replace = F )
+train = iris[train_index,]
+
+test = iris[-train_index,]
+
+
+# Expected answers --------------------------------------------------------
+
+expected_cols <- c("model_label", "dataset_label", "y_true",
+                   "prob_setosa", "prob_versicolor", "prob_virginica",
+                   "dcl_setosa", "dcl_versicolor", "dcl_virginica")
+
+expected_col_types <- c("factor", "factor", "factor", "numeric",
+                        "numeric", "numeric", "numeric", "numeric",
+                        "numeric")
+
+
+
+
+# H2o tests ---------------------------------------------------------------
+
+# Load H2o and initialise -----------------------------------------------
+library(h2o)
+
+h2o.init()
+h2o.no_progress()
+
+h2o_train <- train %>%
+  as.h2o()
+
+# Train a GBM -------------------------------------------------------------
+
+h2o_model <- h2o.gbm(y = "Species",
+                     x = setdiff(colnames(train), "Species"),
+                     training_frame = h2o_train,
+                     nfolds = 5)
+
+
+df <- prepare_scores_and_deciles(datasets=list("train","test"),
+                                 dataset_labels = list("train data","test data"),
+                                 models = list("h2o_model"),
+                                 model_labels = list("h2o gbm"),
+                                 target_column="Species")
+
+test_that("h2o models are properly formatted for aggregate_over_deciles", {
+  df <- get("scores_and_deciles")
+  col_names <- colnames(df)
+  col_types <- map_chr(df, ~ class(.))
+
+  expect_equal(colnames(df),  expected_cols)
+  expect_equal(unname(col_types), expected_col_types)
+})
+
+
+# Test MLR support
+trainTask <- mlr::makeClassifTask(data = train, target = "Species")
+testTask <- mlr::makeClassifTask(data = test, target = "Species")
+
+# Test mlr support --------------------------------------------------------
+
+mlr::configureMlr() # this line is needed when using mlr without loading it (mlr::)
+
+task <- mlr::makeClassifTask(data = train, target = "Species")
+lrn <- mlr::makeLearner("classif.randomForest", predict.type = "prob")
+rf <- mlr::train(lrn, task)
+
+
+prepare_scores_and_deciles(datasets=list("train","test"),
+                           dataset_labels = list("train data","test data"),
+                           models = list("rf"),
+                           model_labels = list("random forest"),
+                           target_column="Species")
+
+test_that("mlr models are properly formatted for aggregate_over_deciles", {
+
+  df <- get("scores_and_deciles")
+  col_names <- colnames(df)
+  col_types <- map_chr(df, ~ class(.))
+
+  expect_equal(colnames(df),  expected_cols)
+  expect_equal(unname(col_types), expected_col_types)
+})
+
+
+
+# Test caret support ------------------------------------------------------
+
+rf <- caret::train(Species ~.,data = train, method = "rf")
+
+prepare_scores_and_deciles(datasets=list("train","test"),
+                           dataset_labels = list("train data","test data"),
+                           models = list("rf"),
+                           model_labels = list("random forest"),
+                           target_column="Species")
+
+test_that("caret models are properly formatted for aggregate_over_deciles", {
+
+  df <- get("scores_and_deciles")
+  col_names <- colnames(df)
+  col_types <- map_chr(df, ~ class(.))
+
+  expect_equal(colnames(df),  expected_cols)
+  expect_equal(unname(col_types), expected_col_types)
+})
+


### PR DESCRIPTION
Hi Jurrr, 

Keen to start using this package in some of my day to day - looks great for reporting to stakeholders etc. In this pull request I have added the following:

* Updated the suggests list to include `e1071` which is needed by `caret`.
* Support for `h2o` models in `prepare_scores_and_deciles`
* Updated `mlr` model catching so that it fails correctly (rather than erroring) when a h2o model is passed in `prepare_scores_and_deciles`
* Updated the package example to include `h2o` models
* Added `testthat` tests for `prepare_scores_and_deciles` for all models types. Note these tests will not currently run in an automated fashion when called with `devtools::test` as the environment handling is very tricky. Instead you need to manually source the tests - not really ideal but couldn't find a workaround.
* Added a very simple README pointing at your blog post so that I can recommend this package to colleagues - happy to remove if desired. 

Thanks, 

Sam